### PR TITLE
tap to click in event shortcuts - hide opacity set to 0

### DIFF
--- a/build/library.js
+++ b/build/library.js
@@ -433,7 +433,7 @@
   };
 
   Layer.prototype.hide = function() {
-    this.opacity = 1;
+    this.opacity = 0;
     return this.style.pointerEvents = 'none';
   };
 

--- a/library.coffee
+++ b/library.coffee
@@ -397,7 +397,7 @@ Layer::show = ->
   @opacity = 1
 
 Layer::hide = ->
-  @opacity = 1
+  @opacity = 0
   @style.pointerEvents = 'none'
 
 


### PR DESCRIPTION
I think there was a typo in the event name. "tap" was in there twice.
