### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Our Development Process
 Internal updates to this library are synced upstream frequently.
 


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the shortcuts-for-framer community profile](https://github.com/facebook/shortcuts-for-framer/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1307" alt="screen shot 2017-11-26 at 1 56 05 pm" src="https://user-images.githubusercontent.com/1114467/33244751-c2c2e1d0-d2b1-11e7-9aed-90fc5cb6e04e.png">
<img width="1317" alt="screen shot 2017-11-26 at 1 56 44 pm" src="https://user-images.githubusercontent.com/1114467/33244752-c2de357a-d2b1-11e7-927d-9ef9412da46c.png">


**issue:**
internal task t23481323